### PR TITLE
Add .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+OPENAI_API_KEY=sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+BOT_PRIVATE_KEY_HEX="XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+BOT_NEWS_API_KEY="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"


### PR DESCRIPTION
`.env.example` is mentioned in the `README.md`, but not exists.